### PR TITLE
Clearer installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ We are building a manjaro sway edition - with the following principles:
 You can find the weekly ISO images on [github releases](https://github.com/manjaro-sway/manjaro-sway/releases).
 To extract the regular images, download both the `z01` and the `zip` files, and run the command:
 
-    cat *.z* >tmp.zip && unzip tmp.zip
+```bash
+cat *.z* >tmp.zip && unzip tmp.zip
 
 You can create a bootable USB stick using [Etcher](https://www.balena.io/etcher/). 
 Check our [FAQ](SUPPORT.md) for additional hints.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We are building a manjaro sway edition - with the following principles:
 ## How to install
 
 You can find the weekly ISO images on [github releases](https://github.com/manjaro-sway/manjaro-sway/releases).
-To extract the image, download both the `z01` and the `zip` files, and run the command:
+To extract the regular images, download both the `z01` and the `zip` files, and run the command:
 
     cat *.z* >tmp.zip && unzip tmp.zip
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To extract the regular images, download both the `z01` and the `zip` files, and 
 
 ```bash
 cat *.z* >tmp.zip && unzip tmp.zip
+```
 
 You can create a bootable USB stick using [Etcher](https://www.balena.io/etcher/). 
 Check our [FAQ](SUPPORT.md) for additional hints.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We are building a manjaro sway edition - with the following principles:
 
 ## How to install
 
-You can find the daily ISO images on [github releases](https://github.com/manjaro-sway/manjaro-sway/releases).
+You can find the weekly ISO images on [github releases](https://github.com/manjaro-sway/manjaro-sway/releases).
 To extract the image, download both the `z01` and the `zip` files, and run the command:
 
     cat *.z* >tmp.zip && unzip tmp.zip

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ We are building a manjaro sway edition - with the following principles:
 
 ## How to install
 
-### Download the ISO
 You can find the daily ISO images on [github releases](https://github.com/manjaro-sway/manjaro-sway/releases).
 To extract the image, download both the `z01` and the `zip` files, and run the command:
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,18 @@ We are building a manjaro sway edition - with the following principles:
 - prepare opt-out
 - build everything automatically
 
-## Setup
+## How to install
 
-Nightly ISO images with the latest stable and LTS kernels are available on [github releases](https://github.com/manjaro-sway/manjaro-sway/releases).
-Note that you need to download both the `z01` and the `zip` file and then [combine them](https://github.com/Manjaro-Sway/manjaro-sway/blob/main/SUPPORT.md#how-can-i-unzip-the-multi-part-zip-zip--z01).
+### Download the ISO
+You can find the daily ISO images on [github releases](https://github.com/manjaro-sway/manjaro-sway/releases).
+To extract the image, download both the `z01` and the `zip` files, and run the command:
 
-See [here](SUPPORT.md) for any questions.
+    cat *.z* >tmp.zip && unzip tmp.zip
 
-### Caveats
+Then you can create the bootable USB by using the image with [Etcher](https://www.balena.io/etcher/). 
+Check our [FAQ](SUPPORT.md).
+
+## Known issues
 
 - nvidia proprietary drivers <470 are not supported by sway.
 - nvidia's 470 drivers and the 5.14 Kernel have just added sway support for proprietary drivers and are known to cause problems.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To extract the regular images, download both the `z01` and the `zip` files, and 
     cat *.z* >tmp.zip && unzip tmp.zip
 
 You can create a bootable USB stick using [Etcher](https://www.balena.io/etcher/). 
-Check our [FAQ](SUPPORT.md).
+Check our [FAQ](SUPPORT.md) for additional hints.
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To extract the regular images, download both the `z01` and the `zip` files, and 
 
     cat *.z* >tmp.zip && unzip tmp.zip
 
-Then you can create the bootable USB by using the image with [Etcher](https://www.balena.io/etcher/). 
+You can create a bootable USB stick using [Etcher](https://www.balena.io/etcher/). 
 Check our [FAQ](SUPPORT.md).
 
 ## Known issues


### PR DESCRIPTION
I've found at least 2 people plus myself, struggling a bit to find the instructions. So I think it would a good idea to move them to the README.md in a super concise way. We can keep all the extras in the FAQ.

This is a proposal. Feel free to either keep the changes or modify them to your disposal.
Cheers.