### PR TITLE
docs: change information about unzipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ We are building a manjaro sway edition - with the following principles:
 ## How to install
 
 You can find the weekly ISO images on [github releases](https://github.com/manjaro-sway/manjaro-sway/releases).
-To extract the regular images, download both the `z01` and the `zip` files, and run the command:
+To extract the regular images from multipart zip archive, download both the `z01` and the `zip` files, and run the command:
 
 ```bash
-cat *.z* >tmp.zip && unzip tmp.zip
+zip -FF manjaro-sway-*.zip --out manjaro-full.zip && unzip manjaro-full.zip
 ```
 
 You can create a bootable USB stick using [Etcher](https://www.balena.io/etcher/). 


### PR DESCRIPTION
It seems to me that the current information about obtaining an iso image is misleading. I spent a lot of time getting a valid iso file, downloaded zip and z01 files in one directory, but the command presented in the current README was interrupted by an error about incorrect zip file signature, will be better if in the README will be described the standard ways of working with multipart zip.