### PR TITLE
chore: build the iso with the action from manjaro-contrib/release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,9 +112,17 @@ jobs:
           key: pacman-pkg-${{ matrix.branch }}-x86_64-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
           restore-keys: |
             pacman-pkg-${{ matrix.branch }}-x86_64-${{ runner.os }}-${{ runner.arch }}-
+      # the action moved into manjaro-contrib/release, so it has to be on
+      # disk before it can be used; this job checks nothing out otherwise
+      - name: fetch the build action
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: manjaro-contrib/release
+          ref: ea52031e3134917662798102d8c5ed83e464e2d6
+          path: .buildiso
       - id: build
         name: x86_64 build
-        uses: manjaro-contrib/action-buildiso@9dfcf97aff6262844c83042837fca9c6c731a7ad # main
+        uses: ./.buildiso/.github/actions/buildiso
         with:
           iso-profiles-repo: https://github.com/Manjaro-Sway/iso-profiles
           edition: sway


### PR DESCRIPTION
`manjaro-contrib/release` absorbed `action-buildiso` (manjaro-contrib/release#30), so the repository this workflow pins is being retired.

The pin here was ten commits behind and missed, among other things, a mirror failover and the fix without which that failover [never actually ran in a build](https://github.com/manjaro-contrib/action-buildiso/pull/23).

## What changes

```yaml
- name: fetch the build action
  uses: actions/checkout@...
  with:
    repository: manjaro-contrib/release
    ref: ea52031e3134917662798102d8c5ed83e464e2d6
    path: .buildiso
- id: build
  uses: ./.buildiso/.github/actions/buildiso
```

A local action has to be on disk before it can be used, and this job checked nothing out - the remote `uses:` was doing that implicitly. So `release` is checked out into `.buildiso` first.

## Merge order matters

**manjaro-contrib/release#30 has to land before this does.** The `ref` above is the head of that pull request's branch, which is the only commit carrying the action while it is open. Merge this first and the checkout resolves to a commit that is not on any branch.

Once #30 merges, that ref should become the merge commit. Renovate tracks `manjaro-contrib/*` digests, so it will move it on its own; I can also update it by hand before merging if you prefer not to wait.

## Checked

- the workflow parses, and the checkout `path` and the action `uses:` agree: `.buildiso` + `.github/actions/buildiso`
- `action.yml` exists at that path in the referenced commit
- everything else in the step - inputs, `steps.build.outputs.file-path` for the artifact upload - is untouched

Not checked, and only a real run can: that the action works invoked from a second repository's checkout. `$GITHUB_ACTION_PATH` resolves to the action's own directory wherever it lives, which is why its internal script paths need no change, but the first build after this merges is the proof.
