### PR TITLE
chore: drop the arm image build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,56 +35,6 @@ jobs:
       release_tag: ${{ steps.time.outputs.time }}
       longterm: ${{ steps.receive.outputs.longterm-pkg }}
       stable: ${{ steps.receive.outputs.stable-pkg }}
-  build-image:
-    runs-on: ubuntu-24.04-arm
-    needs: [prepare-release]
-    continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        branch: [unstable]
-        device: [rpi4]
-    steps:
-      - name: import sway key
-        run: gpg --keyserver keys.openpgp.org --receive-keys ${{ vars.GPG_KEYID }}
-      - name: prepare pacman pkg cache dir
-        # Owned by the runner user so actions/cache can tar-restore without
-        # sudo (tar needs to chown/utime the dir itself); pacman runs as
-        # root inside basestrap and can still write to it.
-        run: |
-          sudo mkdir -p /var/cache/pacman/pkg
-          sudo chown -R "$USER" /var/cache/pacman/pkg
-      - name: cache pacman packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: /var/cache/pacman/pkg
-          key: pacman-pkg-${{ matrix.branch }}-${{ matrix.device }}-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
-          restore-keys: |
-            pacman-pkg-${{ matrix.branch }}-${{ matrix.device }}-${{ runner.os }}-${{ runner.arch }}-
-      - id: build
-        name: arm build
-        uses: manjaro-contrib/action-buildarmimg@d18252a49e9dbdece2a41dd58b1d2c7c5d96c8bf # main
-        with:
-          device: rpi4
-          edition: sway
-          branch: ${{ matrix.branch }}
-          release-tag: ${{ needs.prepare-release.outputs.release_tag }}
-          arm-profiles-repo: https://github.com/manjaro-sway/arm-profiles.git
-          overlay-repo: https://packages.manjaro-sway.download/${{ matrix.branch }}/aarch64/manjaro-sway.db
-      - name: upload image artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: image-${{ matrix.branch }}-${{ matrix.device }}
-          path: ${{ steps.build.outputs.file-path }}
-          retention-days: 1
-          if-no-files-found: error
-      - name: prune + chmod pacman cache
-        # paccache -rk1 keeps one version per package. chmod opens the tree
-        # for actions/cache's save tar.
-        if: always()
-        run: |
-          sudo paccache -rk1 -c /var/cache/pacman/pkg 2>/dev/null || true
-          sudo chmod -R a+rX /var/cache/pacman/pkg 2>/dev/null || true
   build-iso:
     runs-on: ubuntu-24.04
     needs: [prepare-release]
@@ -186,172 +136,6 @@ jobs:
           name: screenshots-iso-boot-${{ matrix.branch }}
           path: screenshots/
           if-no-files-found: warn
-  test-image-boot:
-    runs-on: ubuntu-24.04-arm
-    needs: [build-image]
-    timeout-minutes: 20
-    env:
-      QEMU_VERSION: '10.1.0'
-      QEMU_PREFIX: ${{ github.workspace }}/.qemu
-    strategy:
-      fail-fast: false
-      matrix:
-        branch: [unstable]
-        device: [rpi4]
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: install runtime deps
-        # build deps go in unconditionally because configure needs to be able
-        # to relink against system libs during install; runtime deps for
-        # extract + KVM go here too.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            mtools fdisk xz-utils zstd qemu-utils \
-            build-essential ninja-build pkg-config \
-            libglib2.0-dev libpixman-1-dev libslirp-dev \
-            libpng-dev linux-image-generic ffmpeg \
-            python3 python3-venv flex bison
-          sudo chmod 666 /dev/kvm || true
-      - name: cache qemu ${{ env.QEMU_VERSION }}
-        id: cache-qemu
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ env.QEMU_PREFIX }}
-          key: qemu-${{ env.QEMU_VERSION }}-${{ runner.os }}-${{ runner.arch }}-v3
-      - name: build qemu (cache miss)
-        if: steps.cache-qemu.outputs.cache-hit != 'true'
-        run: |
-          # Ubuntu 24.04 ships QEMU 8.2.2 which predates -M raspi4b (QEMU 9.0).
-          # Source build of just the aarch64-softmmu target lands at ~50 MB.
-          curl -fsSL "https://download.qemu.org/qemu-${QEMU_VERSION}.tar.xz" | tar -xJ
-          cd "qemu-${QEMU_VERSION}"
-          ./configure \
-            --prefix="${QEMU_PREFIX}" \
-            --target-list=aarch64-softmmu \
-            --enable-kvm \
-            --enable-slirp \
-            --enable-vnc \
-            --disable-docs \
-            --disable-gtk \
-            --disable-sdl \
-            --disable-curses \
-            --disable-tools
-          make -j"$(nproc)"
-          make install
-      - name: prepend qemu to PATH
-        run: echo "${QEMU_PREFIX}/bin" >> $GITHUB_PATH
-      - name: download image
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: image-${{ matrix.branch }}-${{ matrix.device }}
-          path: artifact
-      - name: extract kernel + initramfs
-        run: |
-          IMG=$(ls artifact/*.img* | head -n1)
-          ./ci/extract-rpi-kernel.sh "$IMG"
-      - name: boot smoke test
-        env:
-          SERIAL_LOG_OUT: ${{ github.workspace }}/serial.log
-        run: |
-          # extract-rpi-kernel.sh decompresses in place; pick the resulting raw img
-          IMG=$(ls artifact/*.img | head -n1)
-          ./ci/boot-smoke.sh "$IMG" aarch64
-      - name: upload serial log on failure
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: serial-image-${{ matrix.branch }}-${{ matrix.device }}
-          path: serial.log
-          if-no-files-found: warn
-  test-image-install:
-    # rpi4 equivalent of test-iso-install: the image ships in OEM mode and
-    # overlays/sway/etc/greetd/oem-setup auto-runs calamares on first boot.
-    # We boot the image, wait for the journal entry showing calamares exec.
-    # INJECT_HEADLESS_SWAY bypasses the pam_systemd XDG_RUNTIME_DIR failure
-    # that prevents sway from starting in QEMU — see issue #982.
-    runs-on: ubuntu-24.04-arm
-    needs: [build-image]
-    timeout-minutes: 25
-    env:
-      QEMU_VERSION: '10.1.0'
-      QEMU_PREFIX: ${{ github.workspace }}/.qemu
-    strategy:
-      fail-fast: false
-      matrix:
-        branch: [unstable]
-        device: [rpi4]
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: install runtime deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            mtools fdisk xz-utils zstd qemu-utils \
-            build-essential ninja-build pkg-config \
-            libglib2.0-dev libpixman-1-dev libslirp-dev \
-            libpng-dev \
-            linux-image-generic ffmpeg \
-            python3 python3-venv flex bison
-          sudo chmod 666 /dev/kvm || true
-      - name: cache qemu ${{ env.QEMU_VERSION }}
-        id: cache-qemu
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ env.QEMU_PREFIX }}
-          key: qemu-${{ env.QEMU_VERSION }}-${{ runner.os }}-${{ runner.arch }}-v3
-      - name: build qemu (cache miss)
-        if: steps.cache-qemu.outputs.cache-hit != 'true'
-        run: |
-          curl -fsSL "https://download.qemu.org/qemu-${QEMU_VERSION}.tar.xz" | tar -xJ
-          cd "qemu-${QEMU_VERSION}"
-          ./configure \
-            --prefix="${QEMU_PREFIX}" \
-            --target-list=aarch64-softmmu \
-            --enable-kvm \
-            --enable-slirp \
-            --enable-vnc \
-            --disable-docs \
-            --disable-gtk \
-            --disable-sdl \
-            --disable-curses \
-            --disable-tools
-          make -j"$(nproc)"
-          make install
-      - name: prepend qemu to PATH
-        run: echo "${QEMU_PREFIX}/bin" >> $GITHUB_PATH
-      - name: download image
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: image-${{ matrix.branch }}-${{ matrix.device }}
-          path: artifact
-      - name: installer launch test
-        env:
-          SERIAL_LOG_OUT: ${{ github.workspace }}/serial.log
-          BOOT_MARKER_REGEX: 'calamares'
-          BOOT_VIRT_MACHINE: '1'
-          INJECT_HEADLESS_SWAY: '1'
-          SCREENSHOT_DIR: ${{ github.workspace }}/screenshots
-        run: |
-          IMG=$(ls artifact/*.img* | head -n1)
-          # Boot + greetd + oem-setup + calamares exec — give it 12 min.
-          # Uses -M virt with the runner's kernel (which has virtio-gpu) since
-          # the rpi4 kernel has no virtio drivers and raspi4b has no vc4 GPU.
-          ./ci/boot-smoke.sh "$IMG" aarch64 720
-      - name: upload serial log on failure
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: serial-install-image-${{ matrix.branch }}-${{ matrix.device }}
-          path: serial.log
-          if-no-files-found: warn
-      - name: upload screenshots
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: screenshots-image-install-${{ matrix.branch }}-${{ matrix.device }}
-          path: screenshots/
-          if-no-files-found: warn
   test-iso-install:
     # Level 1 of the install test plan: boot the live ISO and verify the
     # Calamares process actually exec's. Catches installer-package missing,
@@ -404,7 +188,7 @@ jobs:
           if-no-files-found: warn
   trigger-mirror:
     runs-on: ubuntu-24.04
-    needs: [build-iso, build-image, test-iso-boot, test-image-boot, test-iso-install, test-image-install]
+    needs: [build-iso, test-iso-boot, test-iso-install]
     steps:
       - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
@@ -413,7 +197,7 @@ jobs:
           event-type: new_release
   rollback:
     runs-on: ubuntu-24.04
-    needs: [build-iso, build-image, prepare-release]
+    needs: [build-iso, prepare-release]
     if: ${{ failure() || cancelled() }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
The arm build produced an rpi4 image from `manjaro-sway/arm-profiles` and an overlay repository at `packages.manjaro-sway.download`. **Both of those repositories are archived now**, and packages are built centrally in `manjaro-contrib/packages`, which publishes x86_64 only.

## Removed, not disabled

`build-image` could have been given `if: false`, but that breaks the release:

```yaml
trigger-mirror:
  needs: [build-iso, build-image, test-iso-boot, test-image-boot, ...]
  # no if: of its own
```

A skipped `build-image` skips `trigger-mirror` with it, so the release would build and never be announced. `test-image-boot` and `test-image-install` exist only to test that image, so they go too.

## What changes

| job | before | after |
| --- | --- | --- |
| `build-image` | rpi4 on `ubuntu-24.04-arm` | removed |
| `test-image-boot` | boots the image | removed |
| `test-image-install` | installs from it | removed |
| `trigger-mirror` | needs 6 jobs | needs `build-iso`, `test-iso-boot`, `test-iso-install` |
| `rollback` | needs `build-iso`, `build-image`, `prepare-release` | needs `build-iso`, `prepare-release` |

218 lines out, 2 in.

## Checked

- the workflow parses and the job graph has no dangling `needs`
- no `arm`, `rpi4`, `device`, `image-` or `buildarmimg` reference remains anywhere in the file
- the iso path is untouched: `build-iso` -> `test-iso-boot` / `test-iso-install` -> `trigger-mirror` chains as before, on the same runner, with the same artifact names, using the action from manjaro-contrib/release that #1003 switched to

If arm images are wanted again later, this is a revert plus un-archiving `arm-profiles` - but the overlay repository it pulled from would need replacing too, since `manjaro-contrib/packages` does not build aarch64.
