### PR TITLE
chore: pin the build action to a commit that is on a branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: manjaro-contrib/release
-          ref: ea52031e3134917662798102d8c5ed83e464e2d6
+          ref: 582d9a11837a4b2ddf156077b7c12826f9796f6b
           path: .buildiso
       - id: build
         name: x86_64 build


### PR DESCRIPTION
#1003 pinned the branch head of manjaro-contrib/release#30, because that was the only commit carrying the action while that pull request was open. It merged as `582d9a1`, and the branch was deleted with it.

```diff
-          ref: ea52031e3134917662798102d8c5ed83e464e2d6   # branch head of #30
+          ref: 582d9a11837a4b2ddf156077b7c12826f9796f6b   # merge commit of #30
```

`ea52031` still resolves - GitHub keeps unreferenced commits for a while - but nothing points at it, so it is collectable. A build failing because its action checkout suddenly 404s is a bad way to discover that.

Checked that `.github/actions/buildiso/action.yml` exists at `582d9a1` before repinning, and that the workflow still parses with the checkout `path` and the action `uses:` in agreement.
